### PR TITLE
Fix; reduce bundle size by removing lodash and reducing exported icons.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govconnex/ui",
-  "version": "0.0.122-dev3",
+  "version": "0.0.122",
   "description": "GovConnex UI - React Component Library",
   "scripts": {
     "build:tokens": "./tokens-build.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govconnex/ui",
-  "version": "0.0.118",
+  "version": "0.0.121",
   "description": "GovConnex UI - React Component Library",
   "scripts": {
     "build:tokens": "./tokens-build.sh",
@@ -61,6 +61,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-visualizer": "^5.9.0",
     "storybook-addon-designs": "^6.3.1",
     "style-dictionary": "^3.7.2",
     "styled-components": "5.3.8",
@@ -91,7 +92,6 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@popperjs/core": "^2.11.6",
     "classnames": "^2.3.2",
-    "lodash": "^4.17.21",
     "react-helmet": "^6.1.0",
     "react-popper": "^2.3.0",
     "react-table": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govconnex/ui",
-  "version": "0.0.121",
+  "version": "0.0.122-dev3",
   "description": "GovConnex UI - React Component Library",
   "scripts": {
     "build:tokens": "./tokens-build.sh",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,7 +42,18 @@ export default [
         brotliSize: true,
       }),
     ],
-    external: ["styled-components", "react", "react-dom"],
+    external: [
+      "styled-components",
+      "react",
+      "react-dom",
+      // Don-t export these as they're under license AND they blow up the bundle size
+      "@fortawesome/react-fontawesome",
+      "@fortawesome/pro-duotone-svg-icons",
+      "@fortawesome/pro-light-svg-icons",
+      "@fortawesome/pro-regular-svg-icons",
+      "@fortawesome/pro-solid-svg-icons",
+      "@fortawesome/pro-thin-svg-icons",
+    ],
   },
   {
     input: "dist/esm/index.d.ts",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,9 +3,10 @@ import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import postcss from "rollup-plugin-postcss";
 import dts from "rollup-plugin-dts";
+import { visualizer } from "rollup-plugin-visualizer";
 
 import { terser } from "rollup-plugin-terser";
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import json from "@rollup/plugin-json";
 
 import packageJson from "./package.json" assert { type: "json" };
@@ -32,7 +33,14 @@ export default [
       typescript({ tsconfig: "./tsconfig.json" }),
       postcss(),
       terser(),
-      json()
+      json(),
+      visualizer({
+        filename: "./dist/stats.html",
+        title: "Bundle Stats",
+        open: true,
+        gzipSize: true,
+        brotliSize: true,
+      }),
     ],
     external: ["styled-components", "react", "react-dom"],
   },
@@ -41,5 +49,5 @@ export default [
     output: [{ file: "dist/index.d.ts", format: "esm" }],
     plugins: [dts()],
     external: [/\.css$/, "styled-components", "react", "react-dom"],
-  }
+  },
 ];

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -5,12 +5,11 @@ import {
 } from "@fortawesome/react-fontawesome";
 import { fas } from "@fortawesome/pro-solid-svg-icons";
 import { far } from "@fortawesome/pro-regular-svg-icons";
-import { fal } from "@fortawesome/pro-light-svg-icons";
-import { fad } from "@fortawesome/pro-duotone-svg-icons";
-import { fat } from "@fortawesome/pro-thin-svg-icons"
+import { faMoneyBillSimple, faChartLineUp } from "@fortawesome/pro-thin-svg-icons";
+import { faPaperclip } from "@fortawesome/pro-light-svg-icons";
 import { library } from "@fortawesome/fontawesome-svg-core";
 
-library.add(fas, far, fal, fad, fat);
+library.add(fas, far, faPaperclip, faMoneyBillSimple, faChartLineUp);
 
 const Icon = (props: FontAwesomeIconProps) => {
   return <FontAwesomeIcon {...props} />;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,13 +3,6 @@ import {
   FontAwesomeIcon,
   FontAwesomeIconProps,
 } from "@fortawesome/react-fontawesome";
-import { fas } from "@fortawesome/pro-solid-svg-icons";
-import { far } from "@fortawesome/pro-regular-svg-icons";
-import { faMoneyBillSimple, faChartLineUp } from "@fortawesome/pro-thin-svg-icons";
-import { faPaperclip } from "@fortawesome/pro-light-svg-icons";
-import { library } from "@fortawesome/fontawesome-svg-core";
-
-library.add(fas, far, faPaperclip, faMoneyBillSimple, faChartLineUp);
 
 const Icon = (props: FontAwesomeIconProps) => {
   return <FontAwesomeIcon {...props} />;

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -1,10 +1,85 @@
 import React from "react";
 import { render } from "../test-utils";
 
-import Menu from "./Menu";
+import { sortByCategory } from "./Menu";
 
 describe("Menu", () => {
   test("renders the Menu component", () => {
     render(<div></div>);
+  });
+
+  describe("sortByCategory", () => {
+    it("should sort options by category in ascending order", () => {
+      const options = [
+        { category: "b", other: "1" },
+        { category: "a", other: "2" },
+        { category: "c", other: "3" },
+      ];
+      const expected = [
+        { category: "a", other: "2" },
+        { category: "b", other: "1" },
+        { category: "c", other: "3" },
+      ];
+      expect(sortByCategory(options)).toEqual(expected);
+    });
+
+    it("should not mutate the original options array", () => {
+      const options = [
+        { category: "b", other: "1" },
+        { category: "a", other: "2" },
+        { category: "c", other: "3" },
+      ];
+      const originalOptions = [...options]; // make a copy of the original array
+
+      sortByCategory(options);
+
+      expect(options).toEqual(originalOptions);
+    });
+
+    it("should handle an empty array", () => {
+      expect(sortByCategory([])).toEqual([]);
+    });
+
+    it("should handle undefined categories, placing them last", () => {
+      const options = [
+        { category: "b", other: "1" },
+        { category: undefined, other: "2" },
+        { category: "a", other: "3" },
+      ];
+      const expected = [
+        { category: "a", other: "3" },
+        { category: "b", other: "1" },
+        { category: undefined, other: "2" },
+      ];
+      expect(sortByCategory(options)).toEqual(expected);
+    });
+
+    it("should handle all undefined categories", () => {
+      const options = [
+        { category: undefined, other: "1" },
+        { category: undefined, other: "2" },
+        { category: undefined, other: "3" },
+      ];
+      const expected = [
+        { category: undefined, other: "1" },
+        { category: undefined, other: "2" },
+        { category: undefined, other: "3" },
+      ];
+      expect(sortByCategory(options)).toEqual(expected);
+    });
+
+    it("should handle some options without a category property", () => {
+      const options = [
+        { other: "1" },
+        { category: "a", other: "2" },
+        { category: "b", other: "3" },
+      ];
+      const expected = [
+        { category: "a", other: "2" },
+        { category: "b", other: "3" },
+        { other: "1" },
+      ];
+      expect(sortByCategory(options)).toEqual(expected);
+    });
   });
 });

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { Placement } from "@popperjs/core";
-import _ from "lodash";
 import Popover from "../Popover";
 import { StyledMenuList } from "./Menu.styles";
 import ClickAwayListener from "../ClickAwayListener/ClickAwayListener";
@@ -15,7 +14,28 @@ export interface MenuOption {
   text?: string | number;
   category?: string;
   style?: React.CSSProperties;
-  'data-cy'?: string;
+  "data-cy"?: string;
+}
+
+export function sortByCategory(options: MenuOption[]) {
+  return [...options].sort((a, b) => {
+    if (a.category === undefined && b.category === undefined) {
+      return 0;
+    }
+    if (a.category === undefined) {
+      return 1;
+    }
+    if (b.category === undefined) {
+      return -1;
+    }
+    if (a.category < b.category) {
+      return -1;
+    }
+    if (a.category > b.category) {
+      return 1;
+    }
+    return 0;
+  });
 }
 
 export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -36,9 +56,7 @@ const Menu = ({
 }: MenuProps) => {
   const [selectedIndex, setSelectedIndex] = React.useState<number>(-1);
 
-  const sortedOptions = useMemo(() => {
-    return _.toArray(_.sortBy(options, ["category"]));
-  }, [options]);
+  const sortedOptions = useMemo(() => sortByCategory(options), [options]);
 
   useKey(["ArrowDown"], (e) => {
     e.preventDefault();
@@ -81,11 +99,13 @@ const Menu = ({
 
             return (
               <span key={`item-${idx}-${new Date().getTime()}`}>
-                {prev === null || prev.category !== option.category &&
-                  <MenuListHeading>{option.category}</MenuListHeading>}
+                {prev === null ||
+                  (prev.category !== option.category && (
+                    <MenuListHeading>{option.category}</MenuListHeading>
+                  ))}
 
                 <MenuListItem
-                  data-cy={option['data-cy']}
+                  data-cy={option["data-cy"]}
                   button
                   style={option.style}
                   onSelect={() => {

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -4,6 +4,7 @@ import Snackbar, { PopinSnackbar } from "./Snackbar";
 import { withDesign } from "storybook-addon-designs";
 import Icon from "../SvgIcon/Icon";
 import Box from "../Box";
+import {faStar} from "@fortawesome/pro-solid-svg-icons/faStar";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -49,7 +50,7 @@ WithButtons.args = {
 export const WithStartAdornment = Template.bind({});
 WithStartAdornment.args = {
   children: "An action was triggered",
-  startAdornment: <Icon icon={["fas", "heart"]} />,
+  startAdornment: <Icon icon={faStar} />,
 };
 // Add explanation
 WithStartAdornment.parameters = {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,7 +1,6 @@
 import React, { useLayoutEffect, useState,useEffect } from "react";
 import { BottomHighlight, StyledTabs } from "./Tabs.styles";
 import { StyledTab, StyledTypography } from "./Tab.styles";
-import { uniqueId } from "lodash";
 
 // Helpers
 
@@ -111,7 +110,7 @@ const Tabs = (props: TabsProps) => {
               child.props.onClick && child.props.onClick();
             },
             selected: selected.value === child.props?.value,
-            key: uniqueId(),
+            key: `tab-${i}`
           } as {onClick:React.DOMAttributes<HTMLButtonElement>, selected:boolean, key:string} );
         }
         return child;

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -1,0 +1,77 @@
+import { deepMerge, AnyObject } from "./utils"; // replace 'your-file' with actual file name
+
+describe("deepMerge", () => {
+  it("should merge non-conflicting properties", () => {
+    const target = { a: 1, b: 2 };
+    const source = { c: 3, d: 4 };
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it("should override conflicting properties", () => {
+    const target = { a: 1, b: 2 };
+    const source = { b: 3, c: 4 };
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it("should deep merge nested objects", () => {
+    const target = { a: { b: 1 }, c: 2 };
+    const source = { a: { d: 3 }, e: 4 };
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: { b: 1, d: 3 }, c: 2, e: 4 });
+  });
+
+  it("should override conflicting properties in nested objects", () => {
+    const target = { a: { b: 1, c: 2 } };
+    const source = { a: { c: 3, d: 4 } };
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: { b: 1, c: 3, d: 4 } });
+  });
+
+  it("should return target if no source is provided", () => {
+    const target = { a: 1, b: 2 };
+    const result = deepMerge(target);
+
+    expect(result).toEqual(target);
+  });
+
+  it("should return an empty object if no arguments are provided", () => {
+    const result = deepMerge(
+      undefined as any as AnyObject,
+      undefined as any as AnyObject
+    );
+
+    expect(result).toEqual(undefined);
+  });
+
+  it("should not mutate the original sources", () => {
+    const source1 = { a: 1, b: 2 };
+    const source2 = { b: 3, c: 4 };
+    const result = deepMerge({}, source1, source2);
+
+    expect(source1).toEqual({ a: 1, b: 2 });
+    expect(source2).toEqual({ b: 3, c: 4 });
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it("should handle null values", () => {
+    const target = { a: null, b: 2 };
+    const source = { b: null, c: 4 };
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: null, b: null, c: 4 });
+  });
+
+  it("should handle undefined values", () => {
+    const target = { a: undefined, b: 2 };
+    const source = { b: undefined, c: 4 };
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: undefined, b: undefined, c: 4 });
+  });
+});

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,0 +1,23 @@
+export type AnyObject = { [key: string]: any };
+
+export function isObject(item: any): item is AnyObject {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+export function deepMerge(target: AnyObject, ...sources: AnyObject[]): AnyObject {
+  if (!sources.length) return target;
+  const source = sources.shift();
+  
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        deepMerge(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+
+  return deepMerge(target, ...sources);
+}

--- a/src/theming/dark-theme.test.ts
+++ b/src/theming/dark-theme.test.ts
@@ -1,0 +1,29 @@
+import { darkTheme } from "./dark-theme";
+
+describe("darkTheme", () => {
+  it('should contain "name" property', () => {
+    expect(darkTheme).toHaveProperty("name");
+    expect(darkTheme.name).toEqual("Dark theme");
+  });
+
+  it("should contain properties from globalTokens", () => {
+    expect(darkTheme).toHaveProperty("typography.display.lg.fontFamily");
+    expect(darkTheme.typography.display.lg.fontFamily).toEqual("Inter");
+  });
+
+  it("should contain properties from lightTokens", () => {
+    expect(darkTheme).toHaveProperty("core.background.bgPrimary");
+    expect(darkTheme.core.background.bgPrimary).toEqual("#ffffff");
+  });
+
+  it("should give precedence to lightTokens when properties conflict", () => {
+    const globalTokens = { conflictProp: "globalValue" };
+    const lightTokens = { conflictProp: "lightValue" };
+
+    const theme = {
+      name: "Light theme",
+      ...Object.assign({}, globalTokens, lightTokens),
+    };
+    expect(theme.conflictProp).toEqual("lightValue");
+  });
+});

--- a/src/theming/dark-theme.ts
+++ b/src/theming/dark-theme.ts
@@ -1,11 +1,11 @@
 import {DefaultTheme} from 'styled-components';
 import darkTokens from "./tokens-output/dark.json";
 import globalTokens from "./tokens-output/global.json";
-import _ from "lodash";
+import {deepMerge} from "../core/utils";
 
 export const darkTheme: DefaultTheme = {
+  ...deepMerge({}, globalTokens, darkTokens) as DefaultTheme,
   "name": "Dark theme",
-  ..._.merge(globalTokens, darkTokens),
 };
 
 export default darkTheme;

--- a/src/theming/light-theme.test.ts
+++ b/src/theming/light-theme.test.ts
@@ -1,0 +1,29 @@
+import { lightTheme } from "./light-theme";
+
+describe("lightTheme", () => {
+  it('should contain "name" property', () => {
+    expect(lightTheme).toHaveProperty("name");
+    expect(lightTheme.name).toEqual("Light theme");
+  });
+
+  it("should contain properties from globalTokens", () => {
+    expect(lightTheme).toHaveProperty("typography.display.lg.fontFamily");
+    expect(lightTheme.typography.display.lg.fontFamily).toEqual("Inter");
+  });
+
+  it("should contain properties from lightTokens", () => {
+    expect(lightTheme).toHaveProperty("core.background.bgPrimary");
+    expect(lightTheme.core.background.bgPrimary).toEqual("#ffffff");
+  });
+
+  it("should give precedence to lightTokens when properties conflict", () => {
+    const globalTokens = { conflictProp: "globalValue" };
+    const lightTokens = { conflictProp: "lightValue" };
+
+    const theme = {
+      name: "Light theme",
+      ...Object.assign({}, globalTokens, lightTokens),
+    };
+    expect(theme.conflictProp).toEqual("lightValue");
+  });
+});

--- a/src/theming/light-theme.ts
+++ b/src/theming/light-theme.ts
@@ -1,12 +1,11 @@
 import {DefaultTheme} from 'styled-components';
 import lightTokens from "./tokens-output/light.json";
 import globalTokens from "./tokens-output/global.json";
-import _ from "lodash";
-
+import {deepMerge} from "../core/utils";
 
 export const lightTheme: DefaultTheme = {
+  ...deepMerge({}, globalTokens, lightTokens) as DefaultTheme,
   "name": "Light theme",
-  ..._.merge(globalTokens, lightTokens)
 };
 
 export default lightTheme;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,6 +11821,16 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
+rollup-plugin-visualizer@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.0.tgz#013ac54fb6a9d7c9019e7eb77eced673399e5a0b"
+  integrity sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==
+  dependencies:
+    open "^8.4.0"
+    picomatch "^2.3.1"
+    source-map "^0.7.4"
+    yargs "^17.5.1"
+
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -12278,7 +12288,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
@@ -13837,6 +13847,19 @@ yargs@^17.3.1, yargs@^17.4.1:
   version "17.7.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
   integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.5.1:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
GZip bundle size 5.7MB -> 1.7MB.

- Removes lodash by replacing the 1-2 functions we were using with plain JS
- Removes light, solid and duotone icon libraries, only import the 2-3 we were actually using.
