### PR TITLE
Fix/uf 128 button fixed width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govconnex/ui",
-  "version": "0.0.122",
+  "version": "0.0.124",
   "description": "GovConnex UI - React Component Library",
   "scripts": {
     "build:tokens": "./tokens-build.sh",

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -28,7 +28,8 @@ const StyledButton = styled.button<{
 position: relative;
   align-items: center;
   cursor: pointer;
-  padding: ${(props) => `0 ${props.noPadding ? "0" : props.theme.spacing.md}`};
+  padding: ${(props) => `${props.noPadding ? "0" : props.theme.spacing.xs} 
+    ${props.noPadding ? "0" : props.theme.spacing[props.size]}`};
   border-radius: ${(props) =>
     props.shape === "rect" || !props.iconOnly
       ? props.theme.borderRadius.xs
@@ -38,10 +39,6 @@ position: relative;
   gap: 12px;
   text-decoration: none !important;
   height: auto;
-
-  & * {
-    line-height: ${(props) => heightMap[props.size]};
-  }
 
   ${({ iconOnly, theme, iconOnlySize }) =>
     iconOnly

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -37,7 +37,7 @@ position: relative;
   display: flex;
   gap: 12px;
   text-decoration: none !important;
-  height: ${(props) => heightMap[props.size]};
+  height: auto;
 
   & * {
     line-height: ${(props) => heightMap[props.size]};

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -88,4 +88,14 @@ describe("StyledButton", () => {
       border-color: ${lightTheme.foundation.error};
     `);
   });
+
+  it("expects to pick up styling", () => {
+    const { getByRole } = renderStyledButton({
+      style: { width: '24px' } 
+    });
+
+    const button = getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveStyle("width: 24px");
+  });
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -27,6 +27,7 @@ export interface ButtonProps
   title?: string;
   isLoading?: boolean;
   noPadding?: boolean;
+  style?: React.CSSProperties;
 }
 
 const typographyMap: Record<ButtonSize, keyof TypographySize> = {
@@ -70,6 +71,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       isLoading = false,
       disabled = false,
       noPadding = false,
+      style,
       ...rest
     },
     ref
@@ -85,6 +87,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         shape={shape || "rect"}
         isLoading={isLoading}
         noPadding={noPadding}
+        style={style}
         {...rest}
       >
         {startAdornment && !isLoading ? (


### PR DESCRIPTION
Changes:
added support for style attribute
changed height to auto to have overflow
added test for style attribute

Here is how it interacts with the app:
This is if we set the style and add a longer text in a button
<img width="1083" alt="Screenshot 2023-07-21 at 11 36 17 AM" src="https://github.com/GovConnex/UI/assets/139733934/4764a161-0396-4648-ac76-5ad21d5913d7">

checked if everything is fine in the app 
<img width="1498" alt="Screenshot 2023-07-21 at 11 36 31 AM" src="https://github.com/GovConnex/UI/assets/139733934/101efe58-edba-4f8f-9050-c2160f5a32fe">

checked if it is okay with smaller screens
![Uploading Screenshot 2023-07-21 at 11.37.38 AM.png…]()


<img width="1167" alt="Screenshot 2023-07-21 at 11 44 09 AM" src="https://github.com/GovConnex/UI/assets/139733934/93cc58d0-01b3-42e8-8dd8-00b61a646f6e">

<img width="528" alt="Screenshot 2023-07-21 at 10 01 00 AM" src="https://github.com/GovConnex/UI/assets/139733934/5c42d1a3-fc7c-4a1f-a5d7-8eb75118c951">
