### PR TITLE
fix: background icon size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govconnex/ui",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "description": "GovConnex UI - React Component Library",
   "scripts": {
     "build:tokens": "./tokens-build.sh",

--- a/src/components/BackgroundIcon/BackgroundIcon.styles.ts
+++ b/src/components/BackgroundIcon/BackgroundIcon.styles.ts
@@ -55,8 +55,8 @@ const StyledBackgroundIcon = styled.div<{size?: SizeProp; cs?: customStyles}>`
   padding: 0;
   background: ${(props) => props.theme.primary.brand["50"]};
   color: ${(props) => props.theme.primary.brand["600"]};
-  width: ${(props) => sizeToWidth(props.size || "sm", props.theme)};
-  height: ${(props) => sizeToWidth(props.size || "sm", props.theme)};
+  width: ${(props) => sizeToWidth(props.size || "sm")};
+  height: ${(props) => sizeToWidth(props.size || "sm")};
 
   ${(props) => addCustomStyles(props)};
 `;


### PR DESCRIPTION
- fixed arguments for size width in background icon

<img width="1508" alt="Screenshot 2023-07-31 at 4 25 04 PM" src="https://github.com/GovConnex/UI/assets/139733934/93eb0ec3-ec9c-4b96-9ad4-f27b37cb1ff6">
